### PR TITLE
Use "delphix/actions/sync-with-upstream" action

### DIFF
--- a/.github/workflows/sync-with-upstream.yml
+++ b/.github/workflows/sync-with-upstream.yml
@@ -1,0 +1,16 @@
+on:
+  schedule:
+    - cron:  '0 * * * *'
+
+jobs:
+  sync:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: delphix/actions/sync-with-upstream@master
+        with:
+          upstream-repository: https://github.com/sdimitro/savedump.git
+          upstream-branch: master
+          downstream-branch: master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Patch `savedump` to use https://github.com/delphix/actions/pull/5

## Testing

Tested by introducing the same change in two branches `test-upstream` and `test-downstream`. The upstream patch had an extra commit that the downstream one and after an hour the following PR was created: https://github.com/sdimitro/savedump/pull/13