### PR TITLE
Use Appropriate Workflow Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # savedump
 
-![](https://github.com/sdimitro/savedump/workflows/.github/workflows/main.yml/badge.svg)
+![](https://github.com/delphix/savedump/workflows/.github/workflows/main.yml/badge.svg)
 
 TL;DR; A Python script that creates a best-effort self-contained
 archive of a kernel crash dump or userland core dump. The archive


### PR DESCRIPTION
As part of the fork we are displaying the status badge of the upstream repo.
Let's change that!