### PR TITLE
Modify tokens used in "sync-with-upstream" workflow

### DIFF
--- a/.github/workflows/sync-with-upstream.yml
+++ b/.github/workflows/sync-with-upstream.yml
@@ -7,10 +7,12 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.DEVOPS_AUTOMATION_TOKEN }}
       - uses: delphix/actions/sync-with-upstream@master
         with:
           upstream-repository: https://github.com/sdimitro/savedump.git
           upstream-branch: master
           downstream-branch: master
         env:
-          GITHUB_TOKEN: ${{ secrets.DEVOPS_AUTOMATION_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This change modifies the tokens used by the "sync-with-upstream"
workflow.

Now we use the token that has admin access when we checkout the
repository initially; this way the "sync-with-upstream" action has admin
access when performing git commands. This specifically is required when
the action attempts to git-push to the "sync-with-upstream" branch, in
order to overcome the usual branch protections.

Further, we don't use the token with admin access via the GITHUB_TOKEN
environment varable; this way the pull request that is opened by the
"sync-with-upstream" action is "owned" by the usual "github-actions"
user, rather than the user associated with the admin token. While this
isn't required, it makes it more consistent with PRs created by other
actions, as those PRs are owned by the "github-actions" user.