### PR TITLE
DLPX-85513 savedump: Fix Bogus Warning About Missing Debug Info

### DIFF
--- a/savedump/savedump.py
+++ b/savedump/savedump.py
@@ -422,7 +422,7 @@ def binary_includes_debug_info(path: str) -> Optional[bool]:
         if '.debug_str' in line:
             debug_str = True
         if debug_info and debug_str:
-            return False
+            return True
     return False
 
 


### PR DESCRIPTION
While trying to archive a userland core dump for SDB's regression suite I came across this minor bug where files that already had debug info were raising errors that they don't have any, like this:
```
warning: could not find debug info of: /export/home/delphix/zfs/.libs/ztest
warning: could not find debug info of: /export/home/delphix/zfs/lib/.libs/libzpool.so.5
warning: could not find debug info of: /export/home/delphix/zfs/lib/.libs/libnvpair.so.3
```

These files were added to the crash dump regardless but the above output is misleading. This patch fixes the issue.