### PR TITLE
DLPX-95936 savedump no longer works on 2025.5.0.0 or higher engines

### DIFF
--- a/savedump/savedump.py
+++ b/savedump/savedump.py
@@ -106,8 +106,15 @@ def get_dump_type(path: str) -> Optional[DumpType]:
     if not success:
         sys.exit(output)
 
+    #
+    # Case-insensitive substring match: `file(1)` reports flattened
+    # kdumps as "Flattened kdump compressed dump" (lowercase 'k') while
+    # non-flattened dumps are still labeled "Kdump compressed dump"
+    # (capital 'K'). Comparing both sides as lowercase recognizes both.
+    #
+    output_lower = output.lower()
     for dump_type in DumpType:
-        if dump_type.value in output:
+        if dump_type.value.lower() in output_lower:
             return dump_type
     return None
 

--- a/savedump/tests/test_get_dump_type.py
+++ b/savedump/tests/test_get_dump_type.py
@@ -1,0 +1,65 @@
+#
+# Copyright 2026 Delphix
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+
+import unittest
+from unittest.mock import patch
+
+from savedump.savedump import DumpType, get_dump_type
+
+
+class GetDumpTypeTest(unittest.TestCase):
+    """
+    `get_dump_type()` shells out to `file(1)` and substring-matches the
+    output against the values of the `DumpType` enum. These tests pin the
+    expected behavior for each form of `file(1)` output we have seen in
+    the field.
+    """
+
+    @staticmethod
+    def _mock_file_output(output: str):
+        return patch('savedump.savedump.shell_cmd', return_value=(True, output))
+
+    def test_legacy_kdump_recognized(self) -> None:
+        """
+        Pre-2025.5.0.0 engines produced non-flattened kdumps; `file(1)`
+        labels these with a capital-K "Kdump compressed dump".
+        """
+        output = ('foo.dump: Kdump compressed dump v6, '
+                  'system Linux, node host, release 5.15.0, ...')
+        with self._mock_file_output(output):
+            self.assertEqual(get_dump_type('foo.dump'), DumpType.CRASHDUMP)
+
+    def test_flattened_kdump_recognized(self) -> None:
+        """
+        2025.5.0.0+ engines produce flattened kdumps (kdump-tools
+        unconditionally adds `-F` to makedumpfile). `file(1)` labels
+        these with a lowercase-k "Flattened kdump compressed dump",
+        which the original case-sensitive substring match against
+        "Kdump compressed dump" missed -- see DLPX-95936.
+        """
+        output = ('foo.dump: Flattened kdump compressed dump v6, '
+                  'system Linux, node host, release 6.17.0, ...')
+        with self._mock_file_output(output):
+            self.assertEqual(get_dump_type('foo.dump'), DumpType.CRASHDUMP)
+
+    def test_userland_core_recognized(self) -> None:
+        output = ('core: ELF 64-bit LSB core file, x86-64, version 1 '
+                  '(SYSV), SVR4-style, from ...')
+        with self._mock_file_output(output):
+            self.assertEqual(get_dump_type('core'), DumpType.UCOREDUMP)
+
+    def test_unknown_returns_none(self) -> None:
+        output = 'foo.txt: ASCII text'
+        with self._mock_file_output(output):
+            self.assertIsNone(get_dump_type('foo.txt'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- `savedump` exits with "unknown core type" on every kernel crash dump produced by 2025.5.0.0+ engines, breaking the [Crash Dump Collection and Analysis](https://perforce.atlassian.net/wiki/spaces/DLXSUP/pages/1558229387/Crash+Dump+Collection+and+Analysis) support SOP.
- Root cause is a case-sensitive substring match in `get_dump_type()` for `'Kdump compressed dump'` (capital K) that doesn't recognize the `'Flattened kdump compressed dump'` (lowercase k) form `file(1)` now reports. The shift to flattened dumps comes from Ubuntu's `kdump-tools` package unconditionally adding `-F` to `MAKEDUMP_ARGS` -- see commit body for details.
- Fix: compare both sides of the substring match in lowercase. Preserves recognition of pre-2025.5.0.0 non-flattened dumps (`'Kdump compressed dump'`) while also recognizing the new flattened form.

## Test plan

- [x] Local unit tests pass: `python3 -m unittest discover savedump/tests`
  - covers both kdump labels (capital-K legacy, lowercase-k flattened), userland core dump, and the negative unknown-format case
  - tests stub `shell_cmd` via `unittest.mock`, so no drgn/libkdumpfile required
- [x] yapf clean: `python3 -m yapf --diff --style google --recursive savedump`
- [x] pylint clean: `python3 -m pylint savedump`
- [x] End-to-end on a fresh `dlpx-develop` VM (build 2026.4.0.0):
  1. Triggered kernel panic via `echo c > /proc/sysrq-trigger`
  2. VM kdumped and rebooted, dump appeared at `/var/crash/<ts>/dump.<ts>`
  3. `file(1)` reported `Flattened kdump compressed dump v6, ...`
  4. **Pre-fix:** `savedump` exits with "unknown core type" (exit 1)
  5. **Post-fix:** `savedump` reports `dump type: kernel crash dump` and proceeds to `archive_kernel_dump`

## Out of scope

- On the engine VM, `archive_kernel_dump` then fails on `import kdumpfile` because the Delphix appliance ships only the `libkdumpfile` C library, not the Python bindings. This is independent of the recognition bug -- savedump is intended to be run on an analysis host with the bindings, per the README. Not addressed here.
- The existing CI workflow (`.github/workflows/main.yml`) targets `ubuntu-18.04`, which GitHub has retired; CI checks against this PR will likely fail for unrelated reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)