### PR TITLE
TOOL-30782 add python3-setuptools to build deps for resolute

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: misc
 Priority: optional
 Maintainer: Delphix Engineering <eng@delphix.com>
 Standards-Version: 4.1.2
-Build-Depends: debhelper (>= 9), dh-python, python3
+Build-Depends: debhelper (>= 9), dh-python, python3, python3-setuptools
 
 Package: savedump
 Architecture: any


### PR DESCRIPTION
## Problem

`savedump` fails to build on Ubuntu 26.04 (resolute) in `linux-pkg/os-upgrade/build-packages/post-push` #1:

```
ModuleNotFoundError: No module named 'setuptools'
dh_auto_clean: error: pybuild --clean -i python{version} -p 3.14 --parallel=2 returned exit code 13
```

Resolute ships Python 3.14, which no longer bundles setuptools. `Build-Depends` was getting it implicitly on noble's 3.12.

## Solution

The solution is to declare `python3-setuptools` in `Build-Depends` rather than rely on it being present.

## Testing Done

Validated by re-running `build-packages/post-push` with `BUILD_POLICY=ALL` against the resolute mirror; results recorded on TOOL-30782.