### PR TITLE
TOOL-30782 declare the python3-setuptools build dep

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: misc
 Priority: optional
 Maintainer: Delphix Engineering <eng@delphix.com>
 Standards-Version: 4.1.2
-Build-Depends: debhelper (>= 9), dh-python, python3
+Build-Depends: debhelper (>= 9), dh-python, python3, python3-setuptools
 
 Package: savedump
 Architecture: any


### PR DESCRIPTION
## Problem

`setup.py` imports `setuptools`, but `debian/control` does not declare it. The build has been getting it from whatever else pulls it in, which holds on noble (Python 3.12 still ships it) and stops holding on Python 3.14, which does not:

```
ModuleNotFoundError: No module named 'setuptools'
dh_auto_clean: error: pybuild --clean -i python{version} -p 3.14 --parallel=2 returned exit code 13
```

## Solution

The solution is to declare it. `python3-setuptools` is present in noble (`68.1.2-2ubuntu1`, verified against the develop mirror), so this is a **no-op on this branch** — it just removes the implicit dependency rather than waiting for the LTS cutover to force it.

Already landed on `os-upgrade`, where it is load-bearing. Raising it here so it is one fewer change to re-land at the Ubuntu 26.04 cutover.

## Testing Done

Not separately built on this branch. The identical change builds clean on `os-upgrade` against Python 3.14, which is the case that actually exercises it; on noble the dependency was already being satisfied implicitly.